### PR TITLE
Small change to setting of HTTP_HOST in tests.InstanceClient.

### DIFF
--- a/instances/tests.py
+++ b/instances/tests.py
@@ -9,13 +9,10 @@ from .models import Instance
 FAKE_URL = 'testing.example.org:8000'
 
 class InstanceClient(Client):
-    def get(self, *args, **kwargs):
-        kwargs['HTTP_HOST'] = FAKE_URL
-        return super(InstanceClient, self).get(*args, **kwargs)
-
-    def post(self, *args, **kwargs):
-        kwargs['HTTP_HOST'] = FAKE_URL
-        return super(InstanceClient, self).post(*args, **kwargs)
+    def __init__(self, enforce_csrf_checks=False, **defaults):
+        defaults.setdefault('HTTP_HOST', FAKE_URL)
+        super(InstanceClient, self).__init__(
+            enforce_csrf_checks=enforce_csrf_checks, **defaults)
 
 @override_settings(
     BASE_HOST='example.org',


### PR DESCRIPTION
Instead of hard-coding HTTP_HOST in just get and post requests
on InstanceClient, set HTTP_HOST in the client's defaults if
it's not set there explicitly.

This has a few beneficial effects:

1) It works for all kinds of request, not just GET and POST.
2) Individual requests can now override this by setting the kwarg
(before this was just discarded)
3) If you wanted for some reason to subclass this client and set
a different HTTP_HOST, you now can. I can't see why you'd want to
do this third one at the moment as the only thing that makes
InstanceClient different is the HTTP_HOST...
