### PR TITLE
Support custom user model

### DIFF
--- a/instances/models.py
+++ b/instances/models.py
@@ -4,15 +4,17 @@ from django.utils.encoding import python_2_unicode_compatible
 
 from .fields import DNSLabelField
 
+
 class InstanceManager(models.Manager):
     def for_instance(self, instance):
         return self.get_query_set().filter(instance=instance)
 
+
 @python_2_unicode_compatible
 class Instance(models.Model):
-    label = DNSLabelField( db_index=True, unique=True )
-    title = models.CharField( max_length=100 )
-    description = models.TextField( blank=True )
+    label = DNSLabelField(db_index=True, unique=True)
+    title = models.CharField(max_length=100)
+    description = models.TextField(blank=True)
     users = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         related_name='instances',
@@ -29,10 +31,14 @@ class Instance(models.Model):
         return u'Instance %s' % self.label
 
     def get_absolute_url(self):
-        url = 'http://%s.%s' % (self.label, getattr(settings, 'BASE_HOST', '127.0.0.1.xip.io'))
+        url = 'http://%s.%s' % (
+            self.label,
+            getattr(settings, 'BASE_HOST', '127.0.0.1.xip.io'),
+            )
         if getattr(settings, 'BASE_PORT', None):
             url += ':%s' % settings.BASE_PORT
         return url
+
 
 class InstanceMixin(models.Model):
     instance = models.ForeignKey(Instance)

--- a/instances/models.py
+++ b/instances/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.utils.encoding import python_2_unicode_compatible
 
 from .fields import DNSLabelField
@@ -14,8 +13,17 @@ class Instance(models.Model):
     label = DNSLabelField( db_index=True, unique=True )
     title = models.CharField( max_length=100 )
     description = models.TextField( blank=True )
-    users = models.ManyToManyField(User, related_name='instances', blank=True)
-    created_by = models.ForeignKey(User, related_name='created_instances', null=True, blank=True)
+    users = models.ManyToManyField(
+        settings.AUTH_USER_MODEL,
+        related_name='instances',
+        blank=True,
+        )
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        related_name='created_instances',
+        null=True,
+        blank=True,
+        )
 
     def __str__(self):
         return u'Instance %s' % self.label

--- a/instances/tests.py
+++ b/instances/tests.py
@@ -2,7 +2,7 @@ from django.test import TestCase, LiveServerTestCase
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.core.validators import ValidationError
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
 from .models import Instance
 
@@ -23,7 +23,7 @@ class InstanceTestCase(TestCase):
 
     def setUp(self):
         self.instance = Instance.objects.create(label='testing')
-        user = User.objects.create_user(username='admin', email='admin@example.org', password='admin')
+        user = get_user_model().objects.create_user(username='admin', email='admin@example.org', password='admin')
         user.instances.add(self.instance)
         self.client.login(username='admin', password='admin')
 
@@ -35,7 +35,7 @@ class InstanceTestCase(TestCase):
 class InstanceLiveServerTestCase(LiveServerTestCase):
     def setUp(self):
         self.instance = Instance.objects.create(label='testing')
-        user = User.objects.create_user(username='admin', email='admin@example.org', password='admin')
+        user = get_user_model().objects.create_user(username='admin', email='admin@example.org', password='admin')
         user.instances.add(self.instance)
 
         self.selenium.get('%s%s' % (self.live_server_url, '/accounts/login/?next=/'))


### PR DESCRIPTION
This should allow someone starting a new project based on django-subdomain-instances (installed from PyPI without using the migrations) to use a custom user model.

For someone developing and using the migrations it should be harmless unless they want to use a custom user model.

<!---
@huboard:{"order":4.0,"milestone_order":4,"custom_state":""}
-->
