### PR TITLE
Avoid hard-coding http.

### DIFF
--- a/instances/middleware.py
+++ b/instances/middleware.py
@@ -26,7 +26,10 @@ class MultiInstanceMiddleware:
         try:
             request.instance = Instance.objects.get(label=matches.group('instance'))
         except:
-            url = 'http://' + domain
+            url = '%(scheme)s://%(domain)s' % {
+                'scheme': 'https' if request.is_secure() else 'http',
+                'domain': domain,
+                }
             if matches.group('port'):
                 url += ':' + matches.group('port')
             return HttpResponseRedirect(url)


### PR DESCRIPTION
Use scheme relative urls to avoid hardcoding http/https.
